### PR TITLE
Update public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11816,6 +11816,14 @@ publishproxy.com
 withgoogle.com
 withyoutube.com
 
+// Hakaran group: http://hakaran.cz
+// Submited by Arseniy Sokolov <security@hakaran.cz>
+caa.li
+conf.se
+fin.ci
+free.hr
+ua.rs
+
 // Hashbang : https://hashbang.sh
 hashbang.sh
 


### PR DESCRIPTION
Added domains caa.li, conf.se, fin.ci, free.hr, ua.rs

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [ ] DNS Verification via dig
* [ ] make test

Description of Organization
====
Hakaran group is medium-size web/vps/server hosting provider in EMEA region.

Reason for PSL Inclusion
====
Hakaran group have many clients who need valid hostname for their application, who need dyn-dns service for their dynamic IP address. We want open registration on this domains for everyone who want short URL of your services what havent got domain or want use free-of-charge dyn-dns service.
Secondary, we want for our users open options for use (sub)domains on services as cloudflare, where is need detect is as separate domain, not only subdomain.

DNS Verification via dig
=======


make test
=========


